### PR TITLE
fix: oneof constructor field validation cyclic

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -2047,7 +2047,7 @@ class Message(ABC):
                     break
             if not set_fields and not is_oneof_fields_has_optional_field:
                 raise ValueError(f"Group {group} has no value; all fields are None")
-            
+
             if len(set_fields) > 1:
                 set_fields_str = ", ".join(set_fields)
                 raise ValueError(

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -2037,9 +2037,18 @@ class Message(ABC):
                 field.name for field in field_set if values[field.name] is not None
             ]
 
-            if not set_fields:
+            # TODO: This is breaking the semantic of oneof but there is no other way of doing a construction
+            # TODO: Without disabling the validation for oneof fields group.
+            is_oneof_fields_has_optional_field = False
+            for field in field_set:
+                bp_meta: "FieldMetadata" = field.metadata.get("betterproto")
+                if bp_meta and bp_meta.optional:
+                    is_oneof_fields_has_optional_field = True
+                    break
+            if not set_fields and not is_oneof_fields_has_optional_field:
                 raise ValueError(f"Group {group} has no value; all fields are None")
-            elif len(set_fields) > 1:
+            
+            if len(set_fields) > 1:
                 set_fields_str = ", ".join(set_fields)
                 raise ValueError(
                     f"Group {group} has more than one value; fields {set_fields_str} are not None"

--- a/tests/inputs/oneof/oneof.proto
+++ b/tests/inputs/oneof/oneof.proto
@@ -21,3 +21,12 @@ message Test {
   }
 }
 
+message Operation {
+  message Ping {}
+  message Pong {}
+  int64 sequence_id = 1;
+  oneof message {
+    Ping ping = 10000;
+    Pong pong = 10001;
+  }
+}

--- a/tests/inputs/oneof/test_oneof.py
+++ b/tests/inputs/oneof/test_oneof.py
@@ -2,23 +2,23 @@ import pytest
 
 import betterproto
 from tests.output_betterproto.oneof import (
-    Operation,
     MixedDrink,
+    Operation,
     Test,
 )
+from tests.output_betterproto_pydantic.oneof import (
+    Operation as OperationPyd2,
+    OperationPing as OperationPingPyd2,
+    OperationPong as OperationPongPyd2,
+    Test as TestPyd2,
+)
+
 # from tests.output_betterproto_pydantic_optionals.oneof import (
 from tests.output_betterproto_pydantic_optionals.oneof import (
     MixedDrink as MixedDrinkPyd,
     Operation as OperationPyd,
     OperationPing as OperationPingPyd,
     OperationPong as OperationPongPyd,
-)
-
-from tests.output_betterproto_pydantic.oneof import (
-    Test as TestPyd2,
-    Operation as OperationPyd2,
-    OperationPing as OperationPingPyd2,
-    OperationPong as OperationPongPyd2,
 )
 from tests.util import get_test_case_json_data
 
@@ -56,7 +56,7 @@ def test_oneof_constructor_pydantic_optionals():
     message3 = OperationPyd().FromString(bytes(message))
     assert message == message3
     assert bytes(message2) == bytes(message3)
-    
+
     with pytest.raises(ValueError):
         OperationPyd(
             sequence_id=-1,
@@ -78,6 +78,7 @@ def test_oneof_constructor_pydantic_optionals():
             ping=OperationPingPyd2(),
             pong=OperationPongPyd2(),
         ).FromString(bytes(message))
+
 
 # Issue #305:
 @pytest.mark.xfail

--- a/tests/inputs/oneof/test_oneof.py
+++ b/tests/inputs/oneof/test_oneof.py
@@ -2,10 +2,24 @@ import pytest
 
 import betterproto
 from tests.output_betterproto.oneof import (
+    Operation,
     MixedDrink,
     Test,
 )
-from tests.output_betterproto_pydantic.oneof import Test as TestPyd
+# from tests.output_betterproto_pydantic_optionals.oneof import (
+from tests.output_betterproto_pydantic_optionals.oneof import (
+    MixedDrink as MixedDrinkPyd,
+    Operation as OperationPyd,
+    OperationPing as OperationPingPyd,
+    OperationPong as OperationPongPyd,
+)
+
+from tests.output_betterproto_pydantic.oneof import (
+    Test as TestPyd2,
+    Operation as OperationPyd2,
+    OperationPing as OperationPingPyd2,
+    OperationPong as OperationPongPyd2,
+)
 from tests.util import get_test_case_json_data
 
 
@@ -22,7 +36,7 @@ def test_which_name():
 
 
 def test_which_count_pyd():
-    message = TestPyd(pitier="Mr. T", just_a_regular_field=2, bar_name="a_bar")
+    message = TestPyd2(pitier="Mr. T", just_a_regular_field=2, bar_name="a_bar")
     assert betterproto.which_one_of(message, "foo") == ("pitier", "Mr. T")
 
 
@@ -32,6 +46,38 @@ def test_oneof_constructor_assign():
     assert field == "mixed_drink"
     assert value.shots == 42
 
+
+def test_oneof_constructor_pydantic_optionals():
+    message = OperationPyd(
+        sequence_id=-1,
+        ping=OperationPingPyd(),
+    )
+    message2 = Operation().FromString(bytes(message))
+    message3 = OperationPyd().FromString(bytes(message))
+    assert message == message3
+    assert bytes(message2) == bytes(message3)
+    
+    with pytest.raises(ValueError):
+        OperationPyd(
+            sequence_id=-1,
+            ping=OperationPingPyd(),
+            pong=OperationPongPyd(),
+        ).FromString(bytes(message))
+
+    # Raises an error unless we define pong, which also will trigger another error
+    # Since oneof fields group is expecting only one field set.
+
+    with pytest.raises(ValueError):
+        OperationPyd2(
+            sequence_id=-1,
+            ping=OperationPingPyd2(),
+        ).FromString(bytes(message))
+    with pytest.raises(ValueError):
+        OperationPyd2(
+            sequence_id=-1,
+            ping=OperationPingPyd2(),
+            pong=OperationPongPyd2(),
+        ).FromString(bytes(message))
 
 # Issue #305:
 @pytest.mark.xfail


### PR DESCRIPTION
semantic changes:
- allowing empty oneof field on constructor

still validates if multiple oneof fields are set

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [] This PR adds something new (e.g. new method or parameters).
    - [x] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
