### PR TITLE
fix: protobuf deserialization repeated field desc

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1439,15 +1439,17 @@ class Message(ABC):
                     parsed.wire_type, meta, field_name, parsed.value
                 )
 
-            # Check type hints 
+            # Check type hints
             fn_unwrap_typ_option = lambda x: getattr(x, "__args__", [None])[0]
             fn_unwrap_typ_option_origin_0 = lambda x: getattr(
                 fn_unwrap_typ_option(x), "__origin__", None
             )
             field_type_hint = fields_type_hint.get(field_name)
-            field_is_repeated = \
-                fn_unwrap_typ_option_origin_0(field_type_hint) is list \
-                    if fields_type_hint else False
+            field_is_repeated = (
+                fn_unwrap_typ_option_origin_0(field_type_hint) is list
+                if fields_type_hint
+                else False
+            )
 
             try:
                 current = getattr(self, field_name)
@@ -1462,7 +1464,9 @@ class Message(ABC):
                     setattr(self, field_name, current)
                 # Value represents a single key/value pair entry in the map.
                 current[value.key] = value.value
-            elif field_is_repeated or (isinstance(current, list) and not isinstance(value, list)):
+            elif field_is_repeated or (
+                isinstance(current, list) and not isinstance(value, list)
+            ):
                 if current is None:
                     current = []
                     setattr(self, field_name, current)

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -1401,6 +1401,8 @@ class Message(ABC):
         if size == SIZE_DELIMITED:
             size, _ = load_varint(stream)
 
+        fields_type_hint = self._type_hints()
+
         # Got some data over the wire
         self._serialized_on_wire = True
         proto_meta = self._betterproto
@@ -1437,6 +1439,16 @@ class Message(ABC):
                     parsed.wire_type, meta, field_name, parsed.value
                 )
 
+            # Check type hints 
+            fn_unwrap_typ_option = lambda x: getattr(x, "__args__", [None])[0]
+            fn_unwrap_typ_option_origin_0 = lambda x: getattr(
+                fn_unwrap_typ_option(x), "__origin__", None
+            )
+            field_type_hint = fields_type_hint.get(field_name)
+            field_is_repeated = \
+                fn_unwrap_typ_option_origin_0(field_type_hint) is list \
+                    if fields_type_hint else False
+
             try:
                 current = getattr(self, field_name)
             except AttributeError:
@@ -1450,11 +1462,14 @@ class Message(ABC):
                     setattr(self, field_name, current)
                 # Value represents a single key/value pair entry in the map.
                 current[value.key] = value.value
-            elif isinstance(current, list) and not isinstance(value, list):
+            elif field_is_repeated or (isinstance(current, list) and not isinstance(value, list)):
                 if current is None:
                     current = []
                     setattr(self, field_name, current)
-                current.append(value)
+                if isinstance(value, list):
+                    current.extend(value)
+                else:
+                    current.append(value)
             else:
                 setattr(self, field_name, value)
 

--- a/tests/inputs/oneof/oneof.proto
+++ b/tests/inputs/oneof/oneof.proto
@@ -24,9 +24,20 @@ message Test {
 message Operation {
   message Ping {}
   message Pong {}
+  message Status {
+    repeated int64 fractions = 100;
+    map<int64, int64> histo  = 101;
+    repeated string strings  = 110;
+    message Module {
+      string name = 1;
+      map<int64, int64> histo = 10;
+    }
+    repeated Module modules = 111;
+  }
   int64 sequence_id = 1;
   oneof message {
-    Ping ping = 10000;
-    Pong pong = 10001;
+    Ping ping     = 10000;
+    Pong pong     = 10001;
+    Status status = 10100;
   }
 }

--- a/tests/inputs/oneof/test_oneof.py
+++ b/tests/inputs/oneof/test_oneof.py
@@ -19,6 +19,8 @@ from tests.output_betterproto_pydantic_optionals.oneof import (
     Operation as OperationPyd,
     OperationPing as OperationPingPyd,
     OperationPong as OperationPongPyd,
+    OperationStatus as OperationStatusPyd,
+    OperationStatusModule as OperationStatusModulePyd,
 )
 from tests.util import get_test_case_json_data
 
@@ -48,6 +50,43 @@ def test_oneof_constructor_assign():
 
 
 def test_oneof_constructor_pydantic_optionals():
+    msg_ctrstr_arr = OperationStatusPyd(
+        strings=["asdf", "asdasdasd", "asdasdasd", "sd"],
+    )
+    msg_ctrstr_arr3 = OperationStatusPyd().FromString(bytes(msg_ctrstr_arr))
+    assert msg_ctrstr_arr == msg_ctrstr_arr3
+
+    _histo_sample = {
+        1: 100,
+        2: 500,
+        3: 600,
+        4: 700,
+        8: 999999999,
+    }
+    msg_ctr_arr = OperationPyd(
+        sequence_id=1,
+        status=OperationStatusPyd(
+            fractions=[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+            histo=_histo_sample,
+            strings=["asdf", "asdasdasd", "asdasdasd", "sd"],
+            modules=[
+                OperationStatusModulePyd(
+                    name="http_client_generic_response_time",
+                    histo=_histo_sample,
+                ),
+                OperationStatusModulePyd(
+                    name="http_server_generic_response_time",
+                    histo=_histo_sample,
+                ),
+            ],
+        ),
+    )
+    msg_ctr_arr2 = Operation().FromString(bytes(msg_ctr_arr))
+    msg_ctr_arr3 = OperationPyd().FromString(bytes(msg_ctr_arr))
+    assert msg_ctr_arr == msg_ctr_arr3
+    assert bytes(msg_ctr_arr) == bytes(msg_ctr_arr3)
+    assert msg_ctr_arr.to_dict() == msg_ctr_arr3.to_dict()
+
     message = OperationPyd(
         sequence_id=-1,
         ping=OperationPingPyd(),
@@ -62,6 +101,7 @@ def test_oneof_constructor_pydantic_optionals():
             sequence_id=-1,
             ping=OperationPingPyd(),
             pong=OperationPongPyd(),
+            status=OperationStatusPyd(),
         ).FromString(bytes(message))
 
     # Raises an error unless we define pong, which also will trigger another error


### PR DESCRIPTION
protobuf deserialization repeated field descriptor treated as scalar for a field that should be receiving repeated data.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [x] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
